### PR TITLE
Fix makefile to use the new names

### DIFF
--- a/Encryptonize.Client/makefile
+++ b/Encryptonize.Client/makefile
@@ -79,7 +79,7 @@ docker-objects-tests-down: ## Stop docker Objects test environment
 	docker-compose --profile objects -f tests/compose.yaml down -v
 
 .PHONY: nuget-pack
-pack: protos ## Pack the library
+nuget-pack: protos ## Pack the library
 	$(call check_defined, VERSION)
 	dotnet pack --output ./artifacts/ --configuration Release /p:Version=${VERSION}
 

--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ tests: ## Run all tests
 client-tests: ## Run Encryptonize client tests
 	@make -C Encryptonize.Client tests
 
-.PHONY: publish
+.PHONY: nuget-publish
 nuget-publish: ## Publish packages
 	@make -C Encryptonize.Client nuget-publish
 


### PR DESCRIPTION
### Description
After the previous PR, some makefile targets changed, but the
changes were not propogated everywhere.

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [X] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [X] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [x] I have pulled in the latest changes from master.
- [ ] I have run `make lint`.
- [ ] I have successfully run `make tests`.
- [x] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [x] I have spent some time looking over the full diff before creating this PR.

