### PR TITLE
Replace '///' comments with '//' comments in proto files

### DIFF
--- a/CyberCrypt.D1.Client/makefile
+++ b/CyberCrypt.D1.Client/makefile
@@ -30,6 +30,10 @@ __check_defined = \
 ##### Build targets #####
 .PHONY: build
 build: ## Build
+	# For some reason the documentation comments doesn't like the comments in the protobuf files
+	# that starts with '///', instead it causes a lot of compilation warnings. Changing comments to '//'
+	# fixes the issue
+	grep -r -l "///" ./src/protos | xargs sed -i 's/\/\/\//\/\//g' || true
 	dotnet build
 
 .PHONY: tests

--- a/makefile
+++ b/makefile
@@ -7,10 +7,6 @@ help:  ## Display this help
 ##### Config #####
 SHELL := /bin/bash
 
-##### Files #####
-export generic_proto_path ?= ../../d1-service-generic/protobuf
-export storage_proto_path ?= ../../d1-service-storage/protobuf
-
 ##### Build targets #####
 .PHONY: build
 build: # Build all clients


### PR DESCRIPTION
### Description
For some reason the .NET documentation generation doesn't like
'///'

### Type(s) of Change (Split the PR if you check many)
- [ ] Added user feature
- [ ] Added technical feature
- [ ] Added tests
- [ ] Refactor
- [X] Bugfix
- [ ] Updated documentation
- [ ] Kubernetes changes
- [ ] CI/CD workflow changes

### Testing Checklist
- [ ] I have added/updated unit tests for functional changes.
- [ ] I have added/updated integration tests for changes that affect dependent systems.
- [ ] I have added/updated end-to-end tests for feature changes.

### General Checklist
- [X] I have pulled in the latest changes from master.
- [ ] I have run `make lint`.
- [ ] I have successfully run `make tests`.
- [ ] I have updated relevant CI/CD workflows.
- [ ] I have updated relevant Kubernetes manifests/scripts.
- [ ] I have updated/added relevant (internal and external) documentation (readme, doc comments, etc).
- [ ] I have updated the dependency map to reflect my changes.
- [ ] I have added the license to new source code files.
- [ ] I have spent some time looking over the full diff before creating this PR.

